### PR TITLE
Accounts back from base64

### DIFF
--- a/net/k8s-cluster/src/bootstrap-startup-script.sh
+++ b/net/k8s-cluster/src/bootstrap-startup-script.sh
@@ -1,0 +1,38 @@
+#!/bin/bash
+
+# Define an array of secret files to process
+SECRET_FILES=(
+    "/home/solana/bootstrap-accounts/identity.base64"
+    "/home/solana/bootstrap-accounts/vote.base64"
+    "/home/solana/bootstrap-accounts/stake.base64"
+)
+
+# Define an array of decoded file paths
+DECODED_FILES=(
+    "/home/solana/identity.json"
+    "/home/solana/vote.json"
+    "/home/solana/stake.json"
+)
+
+# Loop through the secret files
+for i in "${!SECRET_FILES[@]}"; do
+    SECRET_FILE="${SECRET_FILES[i]}"
+    DECODED_FILE="${DECODED_FILES[i]}"
+
+    # Check if the secret file exists
+    if [ -f "$SECRET_FILE" ]; then
+        echo "Secret file found at $SECRET_FILE"
+
+        # Read and decode the base64-encoded secret
+        SECRET_CONTENT=$(cat "$SECRET_FILE" | base64 -d)
+
+        # Save the decoded secret content to a file
+        echo "$SECRET_CONTENT" > "$DECODED_FILE"
+        echo "Decoded secret content saved to $DECODED_FILE"
+    else
+        echo "Secret file not found at $SECRET_FILE"
+    fi
+done
+
+# Sleep for an hour (3600 seconds)
+sleep 3600

--- a/net/k8s-cluster/src/docker.rs
+++ b/net/k8s-cluster/src/docker.rs
@@ -129,6 +129,7 @@ COPY ./{solana_build_directory}/version.yml /home/solana/
 RUN mkdir -p /home/solana/config
 ENV PATH="/home/solana/.cargo/bin:${{PATH}}"
 
+
 WORKDIR /home/solana
 "#,
             self.image_config.base_image
@@ -175,3 +176,9 @@ WORKDIR /home/solana
 // RUN apt install -y iputils-ping curl vim bzip2 psmisc \
 // iproute2 software-properties-common apt-transport-https \
 // ca-certificates openssh-client openssh-server
+
+
+// RUN groupadd -r -g 1000 solana 
+// RUN useradd -m -u 1000 -g solana -s /bin/bash solana
+// RUN useradd -ms /bin/bash solana
+// // RUN chown -R solana:solana /home/solana

--- a/net/k8s-cluster/src/kubernetes.rs
+++ b/net/k8s-cluster/src/kubernetes.rs
@@ -111,7 +111,7 @@ impl<'a> Kubernetes<'a> {
         let accounts_volume = Volume {
             name: "bootstrap-accounts-volume".into(),
             secret: Some(SecretVolumeSource {
-                secret_name: secret_name,
+                secret_name,
                 ..Default::default()
             }),
             ..Default::default()
@@ -126,7 +126,7 @@ impl<'a> Kubernetes<'a> {
 
         // let command = vec!["/workspace/start-bootstrap-validator.sh".to_string()];
         // let command = vec!["sleep".to_string(), "3600".to_string()];
-        let command = vec!["/home/solana/k8s-cluster/src/bootstrap-startup-script.sh".to_string()];
+        let command = vec!["/home/solana/k8s-cluster/src/scripts/bootstrap-startup-script.sh".to_string(), ];
         // let command = vec!["nohup"]
 
         self.create_replicas_set(
@@ -437,7 +437,8 @@ impl<'a> Kubernetes<'a> {
 
 
         // let command = vec!["/workspace/start-validator.sh".to_string()];
-        let command = vec!["sleep".to_string(), "3600".to_string()];
+        // let command = vec!["sleep".to_string(), "3600".to_string()];
+        let command = vec!["/home/solana/k8s-cluster/src/scripts/validator-startup-script.sh".to_string(), ];
 
         self.create_replicas_set(
             format!("validator-{}", validator_index).as_str(),

--- a/net/k8s-cluster/src/scripts/bootstrap-startup-script.sh
+++ b/net/k8s-cluster/src/scripts/bootstrap-startup-script.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+set -e
+/home/solana/k8s-cluster/src/scripts/decode-accounts.sh -t "bootstrap"
+
+# Sleep for an hour (3600 seconds)
+sleep 3600

--- a/net/k8s-cluster/src/scripts/decode-accounts.sh
+++ b/net/k8s-cluster/src/scripts/decode-accounts.sh
@@ -1,10 +1,25 @@
 #!/bin/bash
+set -e
+validator_type=""
+
+while getopts "t:" opt; do
+  case "$opt" in
+    t) validator_type="$OPTARG";;
+    \?) echo "Usage: $0 -t <validator_type>"; exit 1;;
+  esac
+done
+
+# Check if validator_type is empty
+if [ -z "$validator_type" ]; then
+  echo "Validator type is required. Usage: $0 -t <validator_type>"
+  exit 1
+fi
 
 # Define an array of secret files to process
 SECRET_FILES=(
-    "/home/solana/bootstrap-accounts/identity.base64"
-    "/home/solana/bootstrap-accounts/vote.base64"
-    "/home/solana/bootstrap-accounts/stake.base64"
+    "/home/solana/${validator_type}-accounts/identity.base64"
+    "/home/solana/${validator_type}-accounts/vote.base64"
+    "/home/solana/${validator_type}-accounts/stake.base64"
 )
 
 # Define an array of decoded file paths
@@ -33,6 +48,3 @@ for i in "${!SECRET_FILES[@]}"; do
         echo "Secret file not found at $SECRET_FILE"
     fi
 done
-
-# Sleep for an hour (3600 seconds)
-sleep 3600

--- a/net/k8s-cluster/src/scripts/validator-startup-script.sh
+++ b/net/k8s-cluster/src/scripts/validator-startup-script.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+set -e
+/home/solana/k8s-cluster/src/scripts/decode-accounts.sh -t "validator"
+
+# Sleep for an hour (3600 seconds)
+sleep 3600


### PR DESCRIPTION
#### Problem
accounts are mounted as base64 strings as required by kubernetes.

#### Summary of Changes
Convert base64 strings back into normal text and store in file that can be read by `solana-validator --identity`

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
