### PR TITLE
add in command line args for validator/bootstrap configurability

### DIFF
--- a/net/k8s-cluster/src/scripts/bootstrap-startup-script.sh
+++ b/net/k8s-cluster/src/scripts/bootstrap-startup-script.sh
@@ -1,7 +1,17 @@
 #!/bin/bash
 set -e
+
+echo "about to show args: "
+mkdir logs
+touch logs/tmp.log
+args=("$@")
+for arg in "${args[@]}"; do
+  echo "Bootstrap Argument: $arg" >> logs/tmp.log
+done
+
 /home/solana/k8s-cluster/src/scripts/decode-accounts.sh -t "bootstrap"
 
+# see multinode-demo/boostrap-validator.sh for these default commands
 nohup solana-validator \
   --no-os-network-limits-test \
   --no-wait-for-vote-to-start-leader \
@@ -9,14 +19,16 @@ nohup solana-validator \
   --identity identity.json \
   --vote-account vote.json \
   --ledger ledger \
-  --log logs/solana-validator.log \
+  --log - \
   --gossip-host $MY_POD_IP \
   --gossip-port 8001 \
   --rpc-port 8899 \
   --rpc-faucet-address $MY_POD_IP:9900 \
+  --no-poh-speed-test \
+  --no-incremental-snapshots \
   --full-rpc-api \
   --allow-private-addr \
-  >logs/init-validator.log 2>&1 &
+  "$@" &
 
 nohup solana-faucet --keypair faucet.json >logs/faucet.log 2>&1 &
 

--- a/net/k8s-cluster/src/scripts/bootstrap-startup-script.sh
+++ b/net/k8s-cluster/src/scripts/bootstrap-startup-script.sh
@@ -2,12 +2,29 @@
 set -e
 
 echo "about to show args: "
-mkdir logs
-touch logs/tmp.log
-args=("$@")
-for arg in "${args[@]}"; do
-  echo "Bootstrap Argument: $arg" >> logs/tmp.log
+
+# Iterate through the command-line arguments
+args=()
+while [ $# -gt 0 ]; do
+  if [[ ${1:0:2} = -- ]]; then
+    echo "first arg: $1"
+    if [[ $1 == --tpu-enable-udp ]]; then
+      args+=($1)
+      shift 1
+    elif [[ $1 == --tpu-disable-quic ]]; then
+      args+=($1)
+      shift 1
+    else
+      echo "Unknown argument: $1"
+      exit 1
+    fi
+  fi
 done
+
+for arg in "${args[@]}"; do
+  echo "Argument: $arg"
+done
+
 
 /home/solana/k8s-cluster/src/scripts/decode-accounts.sh -t "bootstrap"
 
@@ -19,7 +36,7 @@ nohup solana-validator \
   --identity identity.json \
   --vote-account vote.json \
   --ledger ledger \
-  --log - \
+  --log logs/solana-validator.log \
   --gossip-host $MY_POD_IP \
   --gossip-port 8001 \
   --rpc-port 8899 \
@@ -28,7 +45,8 @@ nohup solana-validator \
   --no-incremental-snapshots \
   --full-rpc-api \
   --allow-private-addr \
-  "$@" &
+  "${args[@]}" \
+   >logs/init-validator.log 2>&1 &
 
 nohup solana-faucet --keypair faucet.json >logs/faucet.log 2>&1 &
 

--- a/net/k8s-cluster/src/scripts/validator-startup-script.sh
+++ b/net/k8s-cluster/src/scripts/validator-startup-script.sh
@@ -1,4 +1,13 @@
 #!/bin/bash
+
+echo "about to show args: "
+mkdir logs
+touch logs/tmp.log
+args=("$@")
+for arg in "${args[@]}"; do
+  echo "Validator Argument: $arg" >> logs/tmp.log
+done
+
 /home/solana/k8s-cluster/src/scripts/decode-accounts.sh -t "validator"
 
 # Maximum number of retries
@@ -62,10 +71,10 @@ nohup solana-validator \
   --gossip-port 8001 \
   --rpc-port 8899 \
   --ledger ledger \
-  --log logs/solana-validator.log \
+  --log - \
   --full-rpc-api \
   --allow-private-addr \
-  >logs/init-validator.log 2>&1 &
+  "$@" &
 
 
 # # Sleep for an hour (3600 seconds)


### PR DESCRIPTION
#### Problem
lots of hard coded stuff. needed to add in command line args

#### Summary of Changes
add in cmd line args for enabling udp and disabling quic
- bootstrap stake and amount of sol
- validator stake and amount of sol

So now we can set stake amounts for both bootstrap and regular validators. 
info passed into genesis and then into scripts that request sol from faucet and run validator code

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
