### PR TITLE
pull genesis from bootstrap onto validators

### DIFF
--- a/k8s-cluster/src/genesis.rs
+++ b/k8s-cluster/src/genesis.rs
@@ -381,17 +381,10 @@ impl Genesis {
     }
 
     // solana-genesis creates a genesis.tar.bz2 but if we need to create snapshots, these
-    // are not included in the genesis.tar.bz2. So we package everything including genesis,
+    // are not included in the genesis.tar.bz2. So we package everything including genesis.tar.bz2,
     // snapshots, etc into genesis-package.tar.bz2 and we use this as our genesis in the
     // bootstrap validator
     pub fn package_up(&mut self) -> Result<(), Box<dyn Error>> {
-        // delete the genesis.tar.bz2 since its contents will be included in the
-        // tar we're about to create
-        let genesis_path = LEDGER_DIR.join("genesis.tar.bz2");
-        if std::fs::metadata(&genesis_path).is_ok() {
-            std::fs::remove_file(&genesis_path)?;
-        }
-
         info!("Packaging genesis");
         let folder_to_tar = LEDGER_DIR.join("");
         let tar_bz2_file = File::create(SOLANA_ROOT.join("config-k8s/genesis-package.tar.bz2"))?;

--- a/k8s-cluster/src/kubernetes.rs
+++ b/k8s-cluster/src/kubernetes.rs
@@ -273,7 +273,7 @@ impl<'a> Kubernetes<'a> {
         .await
     }
 
-    // mount genesis in bootstrap. validators will pull 
+    // mount genesis in bootstrap. validators will pull
     // genesis from bootstrap
     #[allow(clippy::too_many_arguments)]
     async fn create_replicas_set(
@@ -296,7 +296,7 @@ impl<'a> Kubernetes<'a> {
             let Some(config_map_name) = config_map_name else {
                 return Err(boxed_error!("config_map_name is None!"));
             };
-    
+
             let genesis_volume = Volume {
                 name: "genesis-config-volume".into(),
                 config_map: Some(ConfigMapVolumeSource {
@@ -305,13 +305,13 @@ impl<'a> Kubernetes<'a> {
                 }),
                 ..Default::default()
             };
-    
+
             let genesis_volume_mount = VolumeMount {
                 name: "genesis-config-volume".to_string(),
                 mount_path: "/home/solana/genesis".to_string(),
                 ..Default::default()
             };
-            
+
             volumes.push(genesis_volume);
             volume_mounts.push(genesis_volume_mount);
         }
@@ -359,7 +359,7 @@ impl<'a> Kubernetes<'a> {
             },
             spec: Some(replicas_set_spec),
             ..Default::default()
-        })        
+        })
     }
 
     pub async fn deploy_secret(&self, secret: &Secret) -> Result<Secret, kube::Error> {

--- a/k8s-cluster/src/kubernetes.rs
+++ b/k8s-cluster/src/kubernetes.rs
@@ -114,9 +114,9 @@ impl<'a> Kubernetes<'a> {
         if self.validator_config.skip_poh_verify {
             flags.push("--skip-poh-verify".to_string());
         }
-        // if self.validator_config.no_snapshot_fetch {
-        //     flags.push("--no-snapshot-fetch".to_string());
-        // }
+        if self.validator_config.no_snapshot_fetch {
+            flags.push("--no-snapshot-fetch".to_string());
+        }
         if self.validator_config.skip_require_tower {
             flags.push("--skip-require-tower".to_string());
         }

--- a/k8s-cluster/src/ledger_helper.rs
+++ b/k8s-cluster/src/ledger_helper.rs
@@ -42,8 +42,8 @@ impl LedgerHelper {
             .arg("create-snapshot")
             .arg("0")
             .arg(LEDGER_DIR.as_os_str())
-            // .arg("--warp-slot")
-            // .arg(warp_slot.to_string())
+            .arg("--warp-slot")
+            .arg(warp_slot.to_string())
             .output()
             .expect("Failed to execute create-snapshot command");
 

--- a/k8s-cluster/src/ledger_helper.rs
+++ b/k8s-cluster/src/ledger_helper.rs
@@ -42,8 +42,8 @@ impl LedgerHelper {
             .arg("create-snapshot")
             .arg("0")
             .arg(LEDGER_DIR.as_os_str())
-            .arg("--warp-slot")
-            .arg(warp_slot.to_string())
+            // .arg("--warp-slot")
+            // .arg(warp_slot.to_string())
             .output()
             .expect("Failed to execute create-snapshot command");
 

--- a/k8s-cluster/src/main.rs
+++ b/k8s-cluster/src/main.rs
@@ -571,9 +571,7 @@ async fn main() {
             return;
         }
     }
-
-    // std::process::exit(-1);
-
+    
     // Begin Kubernetes Setup and Deployment
     let config_map = match kub_controller.create_genesis_config_map().await {
         Ok(config_map) => {

--- a/k8s-cluster/src/main.rs
+++ b/k8s-cluster/src/main.rs
@@ -571,7 +571,7 @@ async fn main() {
             return;
         }
     }
-    
+
     // Begin Kubernetes Setup and Deployment
     let config_map = match kub_controller.create_genesis_config_map().await {
         Ok(config_map) => {

--- a/k8s-cluster/src/scripts/decode-accounts.sh
+++ b/k8s-cluster/src/scripts/decode-accounts.sh
@@ -60,7 +60,6 @@ for i in "${!SECRET_FILES[@]}"; do
 done
 
 mkdir -p /home/solana/logs
-# mkdir -p /home/solana/ledger
 if [ "$validator_type" == "bootstrap" ]; then
   tar -xvf /home/solana/genesis/genesis-package.tar.bz2 -C /home/solana/
 fi

--- a/k8s-cluster/src/scripts/decode-accounts.sh
+++ b/k8s-cluster/src/scripts/decode-accounts.sh
@@ -61,4 +61,6 @@ done
 
 mkdir -p /home/solana/logs
 # mkdir -p /home/solana/ledger
-tar -xvf /home/solana/genesis/genesis-package.tar.bz2 -C /home/solana/
+if [ "$validator_type" == "bootstrap" ]; then
+  tar -xvf /home/solana/genesis/genesis-package.tar.bz2 -C /home/solana/
+fi


### PR DESCRIPTION
#### Problem
genesis is about to get too big to mount in pods, so we need to pull it from bootstrap. 
This is the first step is enabling the validators to pull genesis

Next step will be to generate genesis on bootstrap startup


Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
