### PR TITLE
thread account creation and add pod labels

### DIFF
--- a/k8s-cluster/src/docker.rs
+++ b/k8s-cluster/src/docker.rs
@@ -58,8 +58,8 @@ impl<'a> DockerConfig<'a> {
             Err(err) => return Err(err),
         };
 
-        info!("Tmp: {}", dockerfile_path.as_path().display());
-        info!("Exists: {}", dockerfile_path.as_path().exists());
+        trace!("Tmp: {}", dockerfile_path.as_path().display());
+        trace!("Exists: {}", dockerfile_path.as_path().exists());
 
         // We use std::process::Command here because Docker-rs is very slow building dockerfiles
         // when they are in large repos. Docker-rs doesn't seem to support the `--file` flag natively.
@@ -160,7 +160,7 @@ WORKDIR /home/solana
             self.insert_client_accounts_if_present()
         );
 
-        info!("dockerfile: {}", dockerfile);
+        debug!("dockerfile: {}", dockerfile);
         std::fs::write(
             docker_path.as_path().join("Dockerfile"),
             content.unwrap_or(dockerfile.as_str()),

--- a/k8s-cluster/src/lib.rs
+++ b/k8s-cluster/src/lib.rs
@@ -56,14 +56,13 @@ pub fn get_solana_root() -> PathBuf {
         .parent()
         .expect("Failed to get Solana root directory")
         .to_path_buf();
-    info!("solana root: {:?}", solana_root);
     solana_root
 }
 
 #[macro_export]
 macro_rules! boxed_error {
     ($message:expr) => {
-        Box::new(std::io::Error::new(std::io::ErrorKind::Other, $message)) as Box<dyn Error>
+        Box::new(std::io::Error::new(std::io::ErrorKind::Other, $message)) as Box<dyn Error + Send>
     };
 }
 

--- a/k8s-cluster/src/main.rs
+++ b/k8s-cluster/src/main.rs
@@ -16,7 +16,7 @@ use {
     solana_ledger::blockstore_cleanup_service::{
         DEFAULT_MAX_LEDGER_SHREDS, DEFAULT_MIN_MAX_LEDGER_SHREDS,
     },
-    solana_sdk::pubkey::Pubkey,
+    solana_sdk::{pubkey::Pubkey, signature::keypair::read_keypair_file, signer::Signer},
     std::{thread, time::Duration},
 };
 
@@ -904,6 +904,18 @@ async fn main() {
         "app.kubernetes.io/name".to_string(),
         "bootstrap-validator-selector".to_string(),
     );
+    bootstrap_rs_labels.insert(
+        "app.kubernetes.io/type".to_string(),
+        "bootstrap".to_string(),
+    );
+
+    let identity_path = get_solana_root().join("config-k8s/bootstrap-validator/identity.json");
+    let bootstrap_keypair =
+        read_keypair_file(identity_path).expect("Failed to read bootstrap keypair file");
+    bootstrap_rs_labels.insert(
+        "app.kubernetes.io/identity".to_string(),
+        bootstrap_keypair.pubkey().to_string(),
+    );
 
     let bootstrap_replica_set = match kub_controller.create_bootstrap_validator_replica_set(
         bootstrap_container_name,
@@ -994,6 +1006,22 @@ async fn main() {
                 "app.kubernetes.io/lb".to_string(),
                 "load-balancer-selector".to_string(),
             );
+            nvv_rs_labels.insert(
+                "app.kubernetes.io/type".to_string(),
+                "non-voting".to_string(),
+            );
+
+            let identity_path = get_solana_root().join(format!(
+                "config-k8s/non-voting-validator-identity-{}.json",
+                nvv_index
+            ));
+            let nvv_keypair = read_keypair_file(identity_path)
+                .expect("Failed to read non voting validator keypair file");
+            nvv_rs_labels.insert(
+                "app.kubernetes.io/identity".to_string(),
+                nvv_keypair.pubkey().to_string(),
+            );
+
             let nvv_secret = match kub_controller.create_non_voting_secret(nvv_index) {
                 Ok(secret) => secret,
                 Err(err) => {
@@ -1105,19 +1133,33 @@ async fn main() {
             }
         }
 
-        let label_selector = kub_controller.create_selector(
+        let mut validator_labels = kub_controller.create_selector(
             "app.kubernetes.io/name",
             format!("validator-{}", validator_index).as_str(),
         );
+        validator_labels.insert(
+            "app.kubernetes.io/type".to_string(),
+            "validator".to_string(),
+        );
 
-        let validator_replica_set: k8s_openapi::api::apps::v1::ReplicaSet = match kub_controller
-            .create_validator_replica_set(
-                validator_container_name,
-                validator_index,
-                validator_image_name,
-                validator_secret.metadata.name.clone(),
-                &label_selector,
-            ) {
+        let identity_path = get_solana_root().join(format!(
+            "config-k8s/validator-identity-{}.json",
+            validator_index
+        ));
+        let validator_keypair =
+            read_keypair_file(identity_path).expect("Failed to read validator keypair file");
+        validator_labels.insert(
+            "app.kubernetes.io/identity".to_string(),
+            validator_keypair.pubkey().to_string(),
+        );
+
+        let validator_replica_set = match kub_controller.create_validator_replica_set(
+            validator_container_name,
+            validator_index,
+            validator_image_name,
+            validator_secret.metadata.name.clone(),
+            &validator_labels,
+        ) {
             Ok(replica_set) => replica_set,
             Err(err) => {
                 error!("Error creating validator replicas_set: {}", err);
@@ -1147,7 +1189,7 @@ async fn main() {
 
         let validator_service = kub_controller.create_validator_service(
             format!("validator-{}-service", validator_index).as_str(),
-            &label_selector,
+            &validator_labels,
         );
         match kub_controller.deploy_service(&validator_service).await {
             Ok(_) => info!(


### PR DESCRIPTION
#### Problem
takes forever to create accounts
need a way to get validators by type and by identity pubkey

#### Summary of Changes
thread account creation
add pod labels:
```
app.kubernetes.io/identity=<pubkey>
app.kubernetes.io/type=<validator-type>
```
Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
