### PR TITLE
fix account bug in client add support for multiple arguments

### DIFF
--- a/k8s-cluster/src/genesis.rs
+++ b/k8s-cluster/src/genesis.rs
@@ -261,7 +261,7 @@ impl Genesis {
         &mut self,
         number_of_clients: i32,
         target_lamports_per_signature: u64,
-        bench_tps_args: Vec<String>,
+        bench_tps_args: Option<Vec<String>>,
     ) -> Result<(), Box<dyn Error>> {
         let client_accounts_file = SOLANA_ROOT.join("config-k8s/client-accounts.yml");
         for i in 0..number_of_clients {
@@ -272,12 +272,12 @@ impl Genesis {
             args.push("--target-lamports-per-signature".to_string());
             args.push(target_lamports_per_signature.to_string());
 
-            if !bench_tps_args.is_empty() {
-                args.extend(bench_tps_args.clone());
-            }
-
-            for i in bench_tps_args.iter() {
-                info!("bench_tps_arg: {}", i);
+            if bench_tps_args.is_some() {
+                let list_of_bench_tps_args = bench_tps_args.as_ref().unwrap();
+                args.extend(list_of_bench_tps_args.clone()); //can unwrap since we checked is_some()
+                for i in list_of_bench_tps_args.iter() {
+                    info!("bench_tps_arg: {}", i);
+                }
             }
 
             info!("generating client accounts...");

--- a/k8s-cluster/src/kubernetes.rs
+++ b/k8s-cluster/src/kubernetes.rs
@@ -95,7 +95,7 @@ pub struct ClientConfig {
     pub client_delay_start: u64,
     pub client_type: String,
     pub client_to_run: String,
-    pub bench_tps_args: Vec<String>,
+    pub bench_tps_args: Option<Vec<String>>,
     pub target_node: Option<Pubkey>,
     pub duration: u64,
     pub num_nodes: Option<u64>,
@@ -276,8 +276,11 @@ impl<'a> Kubernetes<'a> {
         let mut flags = vec![];
 
         flags.push(self.client_config.client_to_run.clone()); //client to run
-        let bench_tps_args = self.client_config.bench_tps_args.join(" ");
-        flags.push(bench_tps_args);
+        if let Some(bench_tps_args) = &self.client_config.bench_tps_args {
+            flags.push(bench_tps_args.join(" "));
+        }
+        // let bench_tps_args = self.client_config.bench_tps_args.expect("Need bench_tps_args!").join(" ");
+        // flags.push(bench_tps_args);
         flags.push(self.client_config.client_type.clone());
 
         if let Some(target_node) = self.client_config.target_node {

--- a/k8s-cluster/src/lib.rs
+++ b/k8s-cluster/src/lib.rs
@@ -159,5 +159,5 @@ pub fn parse_and_format_bench_tps_args(bench_tps_args: Option<&str>) -> Option<V
             .filter_map(|arg| arg.split_once('='))
             .flat_map(|(key, value)| vec![format!("--{}", key), value.to_string()])
             .collect()
-})
+    })
 }

--- a/k8s-cluster/src/lib.rs
+++ b/k8s-cluster/src/lib.rs
@@ -10,6 +10,7 @@ use {
         io::{self, BufReader, Cursor, Read},
         path::{Path, PathBuf},
         time::Duration,
+        collections::HashMap,
     },
     tar::Archive,
     url::Url,
@@ -151,4 +152,13 @@ pub fn cat_file(path: &PathBuf) -> io::Result<()> {
     info!("{}", contents);
 
     Ok(())
+}
+
+pub fn parse_and_format_bench_tps_args(bench_tps_args: Option<&str>) -> Option<Vec<String>> {
+    bench_tps_args.map(|args| {
+        args.split_whitespace()
+            .filter_map(|arg| arg.split_once('='))
+            .flat_map(|(key, value)| vec![format!("--{}", key), value.to_string()])
+            .collect()
+})
 }

--- a/k8s-cluster/src/lib.rs
+++ b/k8s-cluster/src/lib.rs
@@ -10,7 +10,6 @@ use {
         io::{self, BufReader, Cursor, Read},
         path::{Path, PathBuf},
         time::Duration,
-        collections::HashMap,
     },
     tar::Archive,
     url::Url,

--- a/k8s-cluster/src/main.rs
+++ b/k8s-cluster/src/main.rs
@@ -336,10 +336,9 @@ fn parse_matches() -> ArgMatches<'static> {
                 User can optionally provide extraArgs that are transparently
                 supplied to the client program as command line parameters.
                 For example,
-                    --bench-tps-args 'tx-count=25000'
-                This will start bench-tps clients, and supply '--tx-count 25000'
-                to the bench-tps client.
-                Multiple args not yet supported!"),
+                    --bench-tps-args 'tx-count=5000 thread-batch-sleep-ms=250'
+                This will start bench-tps clients, and supply '--tx-count 5000 --thread-batch-sleep-ms 250'
+                to the bench-tps client."),
         )
         .arg(
             Arg::with_name("target_node")

--- a/k8s-cluster/src/main.rs
+++ b/k8s-cluster/src/main.rs
@@ -7,7 +7,7 @@ use {
             Genesis, GenesisFlags, DEFAULT_CLIENT_LAMPORTS_PER_SIGNATURE,
             DEFAULT_INTERNAL_NODE_SOL, DEFAULT_INTERNAL_NODE_STAKE_SOL,
         },
-        get_solana_root, initialize_globals,
+        get_solana_root, initialize_globals, parse_and_format_bench_tps_args,
         kubernetes::{ClientConfig, Kubernetes, Metrics, NodeAffinityType, ValidatorConfig},
         ledger_helper::LedgerHelper,
         release::{BuildConfig, Deploy},
@@ -335,8 +335,8 @@ fn parse_matches() -> ArgMatches<'static> {
                 User can optionally provide extraArgs that are transparently
                 supplied to the client program as command line parameters.
                 For example,
-                    --bench-tps-args tx_count=25000
-                This will start bench-tps clients, and supply '--tx_count 25000'
+                    --bench-tps-args 'tx-count=25000'
+                This will start bench-tps clients, and supply '--tx-count 25000'
                 to the bench-tps client.
                 Multiple args not yet supported!"),
         )
@@ -468,22 +468,7 @@ async fn main() {
             .value_of("client_to_run")
             .unwrap_or_default()
             .to_string(),
-        bench_tps_args: matches
-            .values_of("bench_tps_args")
-            .unwrap_or_default()
-            .flat_map(|arg| {
-                arg.split('=')
-                    .enumerate()
-                    .map(|(idx, s)| {
-                        if idx == 0 {
-                            format!("--{}", s) // prepend '--' to the flag
-                        } else {
-                            s.to_string()
-                        }
-                    })
-                    .collect::<Vec<String>>()
-            })
-            .collect(),
+        bench_tps_args: parse_and_format_bench_tps_args(matches.value_of("bench_tps_args")),
         target_node: match matches.value_of("target_node") {
             Some(s) => match s.parse::<Pubkey>() {
                 Ok(pubkey) => Some(pubkey),
@@ -496,6 +481,15 @@ async fn main() {
             .value_of("num_nodes")
             .map(|value_str| value_str.parse().expect("Invalid value for num_nodes")),
     };
+
+
+
+    if let Some(ref bench_tps_args) = client_config.bench_tps_args {
+        for s in bench_tps_args.iter() {
+            info!("s: {}", s);
+        }
+
+    }
 
     let build_config = BuildConfig {
         release_channel: matches.value_of("release_channel").unwrap_or_default(),

--- a/k8s-cluster/src/main.rs
+++ b/k8s-cluster/src/main.rs
@@ -7,9 +7,10 @@ use {
             Genesis, GenesisFlags, DEFAULT_CLIENT_LAMPORTS_PER_SIGNATURE,
             DEFAULT_INTERNAL_NODE_SOL, DEFAULT_INTERNAL_NODE_STAKE_SOL,
         },
-        get_solana_root, initialize_globals, parse_and_format_bench_tps_args,
+        get_solana_root, initialize_globals,
         kubernetes::{ClientConfig, Kubernetes, Metrics, NodeAffinityType, ValidatorConfig},
         ledger_helper::LedgerHelper,
+        parse_and_format_bench_tps_args,
         release::{BuildConfig, Deploy},
         ValidatorType,
     },
@@ -482,13 +483,10 @@ async fn main() {
             .map(|value_str| value_str.parse().expect("Invalid value for num_nodes")),
     };
 
-
-
     if let Some(ref bench_tps_args) = client_config.bench_tps_args {
         for s in bench_tps_args.iter() {
             info!("s: {}", s);
         }
-
     }
 
     let build_config = BuildConfig {

--- a/k8s-cluster/src/scripts/client-startup-script.sh
+++ b/k8s-cluster/src/scripts/client-startup-script.sh
@@ -1,23 +1,6 @@
 #!/bin/bash
 # set -e
 
-SECRET_FILE="/home/solana/client-accounts/faucet.base64"
-DECODED_FILE="/home/solana/faucet.json"
-
-# Check if the secret file exists
-if [ -f "$SECRET_FILE" ]; then
-    echo "Secret file found at $SECRET_FILE"
-
-    # Read and decode the base64-encoded secret
-    SECRET_CONTENT=$(base64 -d < "$SECRET_FILE")
-
-    # Save the decoded secret content to a file
-    echo "$SECRET_CONTENT" > "$DECODED_FILE"
-    echo "Decoded secret content saved to $DECODED_FILE"
-else
-    echo "Secret file not found at $SECRET_FILE"
-fi
-
 mkdir -p /home/solana/logs
 
 clientToRun="$1"
@@ -30,7 +13,7 @@ runtime_args=()
 while [[ -n $1 ]]; do
   if [[ ${1:0:1} = - ]]; then
     if [[ $1 = --target-node ]]; then
-      echo "--target-node not supported yet...not including" >> logs/client.log 2>&1
+      echo "--target-node not supported yet...not included" >> logs/client.log 2>&1
       # runtime_args+=("$1" "$2")
       shift 2
     elif [[ $1 = --duration ]]; then

--- a/k8s-cluster/src/scripts/client-startup-script.sh
+++ b/k8s-cluster/src/scripts/client-startup-script.sh
@@ -44,6 +44,8 @@ if [[ $threadCount -gt 4 ]]; then
   threadCount=4
 fi
 
+echo "threadCount: $threadCount"
+
 TPU_CLIENT=false
 RPC_CLIENT=false
 case "$clientType" in
@@ -71,10 +73,12 @@ bench-tps)
 
   if ${TPU_CLIENT}; then
     args+=(--use-tpu-client)
-    args+=(--url "$BOOTSTRAP_RPC_ADDRESS")
+    # args+=(--url "$BOOTSTRAP_RPC_ADDRESS")
+    args+=(--url "$LOAD_BALANCER_RPC_ADDRESS")
   elif ${RPC_CLIENT}; then
     args+=(--use-rpc-client)
-    args+=(--url "$BOOTSTRAP_RPC_ADDRESS")
+    # args+=(--url "$BOOTSTRAP_RPC_ADDRESS")
+    args+=(--url "$LOAD_BALANCER_RPC_ADDRESS")
   else
     args+=(--entrypoint "$BOOTSTRAP_GOSSIP_ADDRESS")
   fi

--- a/k8s-cluster/src/scripts/client-startup-script.sh
+++ b/k8s-cluster/src/scripts/client-startup-script.sh
@@ -39,9 +39,6 @@ missing() {
   exit 1
 }
 
-# [[ -n $deployMethod ]] || missing deployMethod
-# [[ -n $entrypointIp ]] || missing entrypointIp
-
 threadCount=$(nproc)
 if [[ $threadCount -gt 4 ]]; then
   threadCount=4


### PR DESCRIPTION
there was an account decoding bug in the client path. that is now fixed

added support for multiple `bench-tps` arguments. 

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
