### PR TITLE
add pod cpu and mem requests for kubernetes scheduler

### DIFF
--- a/k8s-cluster/src/k8s_helpers.rs
+++ b/k8s-cluster/src/k8s_helpers.rs
@@ -5,11 +5,11 @@ use {
             core::v1::{
                 Affinity, Container, EnvVar, EnvVarSource, NodeAffinity, NodeSelector,
                 NodeSelectorRequirement, NodeSelectorTerm, ObjectFieldSelector, PodSecurityContext,
-                PodSpec, PodTemplateSpec, Probe, Secret, Service, ServicePort, ServiceSpec, Volume,
-                VolumeMount,
+                PodSpec, PodTemplateSpec, Probe, ResourceRequirements, Secret, Service,
+                ServicePort, ServiceSpec, Volume, VolumeMount,
             },
         },
-        apimachinery::pkg::apis::meta::v1::LabelSelector,
+        apimachinery::pkg::{api::resource::Quantity, apis::meta::v1::LabelSelector},
         ByteString,
     },
     kube::api::ObjectMeta,
@@ -46,6 +46,7 @@ pub fn create_replica_set(
     volume_mounts: Option<Vec<VolumeMount>>,
     readiness_probe: Option<Probe>,
     nodes: Option<Vec<String>>,
+    pod_requests: BTreeMap<String, Quantity>,
 ) -> Result<ReplicaSet, Box<dyn Error>> {
     let node_affinity = nodes.clone().map(|_| NodeAffinity {
         required_during_scheduling_ignored_during_execution: Some(NodeSelector {
@@ -75,6 +76,10 @@ pub fn create_replica_set(
                 command: Some(command.to_owned()),
                 volume_mounts,
                 readiness_probe,
+                resources: Some(ResourceRequirements {
+                    requests: Some(pod_requests),
+                    ..Default::default()
+                }),
                 ..Default::default()
             }],
             volumes,

--- a/k8s-cluster/src/main.rs
+++ b/k8s-cluster/src/main.rs
@@ -456,10 +456,10 @@ fn parse_matches() -> ArgMatches<'static> {
             Arg::with_name("cpu_requests")
                 .long("cpu-requests")
                 .takes_value(true)
-                .default_value("10") // 10 cores
+                .default_value("20") // 20 cores
                 .help("Kubernetes pod config. Specify minimum CPUs required for deploying validator.
                     can use millicore notation as well. e.g. 500m (500 millicores) == 0.5 and is equivalent to half a core.
-                    [default: 10]"),
+                    [default: 20]"),
         )
         .arg(
             Arg::with_name("memory_requests")

--- a/k8s-cluster/src/scripts/common.sh
+++ b/k8s-cluster/src/scripts/common.sh
@@ -73,8 +73,6 @@ solana_cli=$(solana_program)
 
 export RUST_BACKTRACE=1
 
-echo "solana command: $solana_validator"
-
 # https://gist.github.com/cdown/1163649
 urlencode() {
   declare s="$1"


### PR DESCRIPTION
Added in pod cpu and mem requests for kubernetes scheduler
default is 70Gi and 20 cores. this can be overridden via command line flags: `--cpu-requests` and `--memory-requests`
