### PR TITLE
use the cli from appropriate release channel for all solana cli commands

### DIFF
--- a/k8s-cluster/README.md
+++ b/k8s-cluster/README.md
@@ -244,6 +244,25 @@ cargo run --bin solana-k8s --
 ```
 ^ note this is not an ideal setup since we have to pass in `--bench-tps-args` for first and last deployment. But `solana-bench-tps` uses `tx-count` to calculate the number of client accounts
 
+## Pod name format
+```
+kubectl get pods -n <namespace>
+```
+You'll see pods with the following format if you provide a `--deployment-tag`
+```
+bootstrap-validator-replicaset-<hash>
+validator-<deployment-tag>-<validator-index>-replicaset-<hash>
+# clients and non voting validators have same format
+```
+
+For services, you'll see something like:
+```
+bootstrap-validator-index
+validator-service-<deployment-tag>-<validator-index>
+# clients and non voting validators have same format
+```
+
+
 ## Deploying with a specific kube config location
 ```
 KUBECONFIG=/path/to/my/kubeconfig cargo run --bin solana-k8s -- ....

--- a/k8s-cluster/src/genesis.rs
+++ b/k8s-cluster/src/genesis.rs
@@ -98,14 +98,14 @@ fn parse_spl_genesis_file(spl_file: &PathBuf) -> Result<Vec<String>, Box<dyn Err
 }
 
 fn append_client_accounts_to_file(
-    in_file: &PathBuf,  //bench-tps-x.yml
+    in_file: &PathBuf,  //bench-tps-i.yml
     out_file: &PathBuf, //client-accounts.yml
 ) -> io::Result<()> {
-    // Open the bench-tps-x file for reading.
+    // Open the bench-tps-i.yml file for reading.
     let input = File::open(in_file)?;
     let reader = io::BufReader::new(input);
 
-    // Open (or create) client-accounts.yml for appending.
+    // Open (or create) client-accounts.yml 
     let output = OpenOptions::new()
         .create(true)
         .append(true)
@@ -276,6 +276,7 @@ impl Genesis {
         number_of_clients: i32,
         target_lamports_per_signature: u64,
         bench_tps_args: Option<Vec<String>>,
+        build_path: PathBuf,
     ) -> Result<(), Box<dyn Error>> {
         let client_accounts_file = SOLANA_ROOT.join("config-k8s/client-accounts.yml");
         for i in 0..number_of_clients {
@@ -295,7 +296,8 @@ impl Genesis {
             }
 
             info!("generating client accounts...");
-            let output = Command::new("solana-bench-tps")
+            let executable_path = build_path.join("solana-bench-tps");
+            let output = Command::new(executable_path)
                 .args(&args)
                 .output()
                 .expect("Failed to execute solana-bench-tps");
@@ -438,7 +440,7 @@ impl Genesis {
         parse_spl_genesis_file(&spl_file)
     }
 
-    pub fn generate(&mut self) -> Result<(), Box<dyn Error>> {
+    pub fn generate(&mut self, build_path: PathBuf) -> Result<(), Box<dyn Error>> {
         let mut args = self.setup_genesis_flags();
         let mut spl_args = self.setup_spl_args()?;
         args.append(&mut spl_args);
@@ -448,7 +450,8 @@ impl Genesis {
             debug!("{}", arg);
         }
 
-        let output = Command::new("solana-genesis")
+        let executable_path = build_path.join("solana-genesis");
+        let output = Command::new(executable_path)
             .args(&args)
             .output()
             .expect("Failed to execute solana-genesis");

--- a/k8s-cluster/src/genesis.rs
+++ b/k8s-cluster/src/genesis.rs
@@ -105,7 +105,7 @@ fn append_client_accounts_to_file(
     let input = File::open(in_file)?;
     let reader = io::BufReader::new(input);
 
-    // Open (or create) client-accounts.yml 
+    // Open (or create) client-accounts.yml
     let output = OpenOptions::new()
         .create(true)
         .append(true)

--- a/k8s-cluster/src/kubernetes.rs
+++ b/k8s-cluster/src/kubernetes.rs
@@ -762,11 +762,13 @@ impl<'a> Kubernetes<'a> {
             debug!("validator command: {}", c);
         }
 
-        let mut replica_set_name_with_optional_tag = format!("validator-{}", validator_index);
+        let mut replica_set_name_with_optional_tag = "validator".to_string();
         if let Some(tag) = &self.deployment_tag {
             replica_set_name_with_optional_tag =
                 add_tag_to_name(replica_set_name_with_optional_tag.as_str(), tag);
         }
+        replica_set_name_with_optional_tag =
+            format!("{}-{}", replica_set_name_with_optional_tag, validator_index);
 
         k8s_helpers::create_replica_set(
             replica_set_name_with_optional_tag.as_str(),
@@ -849,11 +851,13 @@ impl<'a> Kubernetes<'a> {
             ..Default::default()
         };
 
-        let mut replica_set_name_with_optional_tag = format!("non-voting-{}", nvv_index);
+        let mut replica_set_name_with_optional_tag = "non-voting".to_string();
         if let Some(tag) = &self.deployment_tag {
             replica_set_name_with_optional_tag =
                 add_tag_to_name(replica_set_name_with_optional_tag.as_str(), tag);
         }
+        replica_set_name_with_optional_tag =
+            format!("{}-{}", replica_set_name_with_optional_tag, nvv_index);
 
         k8s_helpers::create_replica_set(
             replica_set_name_with_optional_tag.as_str(),
@@ -908,11 +912,13 @@ impl<'a> Kubernetes<'a> {
             debug!("client command: {}", c);
         }
 
-        let mut replica_set_name_with_optional_tag = format!("client-{}", client_index);
+        let mut replica_set_name_with_optional_tag = "client".to_string();
         if let Some(tag) = &self.deployment_tag {
             replica_set_name_with_optional_tag =
                 add_tag_to_name(replica_set_name_with_optional_tag.as_str(), tag);
         }
+        replica_set_name_with_optional_tag =
+            format!("{}-{}", replica_set_name_with_optional_tag, client_index);
 
         k8s_helpers::create_replica_set(
             replica_set_name_with_optional_tag.as_str(),
@@ -934,12 +940,15 @@ impl<'a> Kubernetes<'a> {
         &self,
         service_name: &str,
         label_selector: &BTreeMap<String, String>,
+        index: i32,
     ) -> Service {
         let mut service_name_with_optional_tag = service_name.to_string();
         if let Some(tag) = &self.deployment_tag {
             service_name_with_optional_tag =
                 add_tag_to_name(service_name_with_optional_tag.as_str(), tag);
         }
+        service_name_with_optional_tag = format!("{}-{}", service_name_with_optional_tag, index);
+
         k8s_helpers::create_service(
             service_name_with_optional_tag.as_str(),
             self.namespace,

--- a/k8s-cluster/src/ledger_helper.rs
+++ b/k8s-cluster/src/ledger_helper.rs
@@ -3,7 +3,7 @@ use {
     log::*,
     solana_accounts_db::hardened_unpack::open_genesis_config,
     solana_sdk::{hash::Hash, shred_version::compute_shred_version},
-    std::{error::Error, process::Command, str::FromStr},
+    std::{error::Error, path::PathBuf, process::Command, str::FromStr},
 };
 
 fn ledger_directory_exists() -> Result<(), Box<dyn Error>> {
@@ -29,14 +29,15 @@ impl LedgerHelper {
         Ok(shred_version)
     }
 
-    pub fn create_snapshot(_warp_slot: u64) -> Result<(), Box<dyn Error>> {
+    pub fn create_snapshot(_warp_slot: u64, build_path: PathBuf) -> Result<(), Box<dyn Error>> {
         ledger_directory_exists()?;
         let config_dir = LEDGER_DIR.join("accounts_hash_cache");
         if config_dir.exists() {
             std::fs::remove_dir_all(&config_dir).unwrap();
         }
         std::fs::create_dir_all(&config_dir).unwrap();
-        let output = Command::new("solana-ledger-tool")
+        let executable_path = build_path.join("solana-ledger-tool");
+        let output = Command::new(executable_path)
             .arg("-l")
             .arg(LEDGER_DIR.as_os_str())
             .arg("create-snapshot")
@@ -56,9 +57,10 @@ impl LedgerHelper {
         Ok(())
     }
 
-    pub fn create_bank_hash() -> Result<Hash, Box<dyn Error>> {
+    pub fn create_bank_hash(build_path: PathBuf) -> Result<Hash, Box<dyn Error>> {
         ledger_directory_exists()?;
-        let output = Command::new("solana-ledger-tool")
+        let executable_path = build_path.join("solana-ledger-tool");
+        let output = Command::new(executable_path)
             .arg("-l")
             .arg(LEDGER_DIR.as_os_str())
             .arg("bank-hash")

--- a/k8s-cluster/src/main.rs
+++ b/k8s-cluster/src/main.rs
@@ -1185,8 +1185,9 @@ async fn main() {
                 format!("non-voting-selector-{}", nvv_index).as_str(),
             );
             let nvv_service = kub_controller.create_validator_service(
-                format!("non-voting-{}-service", nvv_index).as_str(),
+                "non-voting-service",
                 &non_voting_label,
+                nvv_index,
             );
 
             //deploy nvv service
@@ -1314,8 +1315,9 @@ async fn main() {
         };
 
         let validator_service = kub_controller.create_validator_service(
-            format!("validator-{}-service", validator_index).as_str(),
+            "validator-service",
             &validator_labels,
+            validator_index,
         );
         match kub_controller.deploy_service(&validator_service).await {
             Ok(_) => info!(
@@ -1399,8 +1401,9 @@ async fn main() {
         };
 
         let client_service = kub_controller.create_validator_service(
-            format!("client-{}-service", client_index).as_str(),
+            "client-service",
             &label_selector,
+            client_index,
         );
         match kub_controller.deploy_service(&client_service).await {
             Ok(_) => info!("client service ({}) deployed successfully", client_index),

--- a/k8s-cluster/src/scripts/non-voting-validator-startup-script.sh
+++ b/k8s-cluster/src/scripts/non-voting-validator-startup-script.sh
@@ -54,7 +54,6 @@ EOF
   exit 1
 }
 
-echo "pre positional args"
 positional_args=()
 while [[ -n $1 ]]; do
   if [[ ${1:0:1} = - ]]; then
@@ -225,12 +224,10 @@ else
   fi
 fi
 
-echo "pre default args"
 default_arg --entrypoint "$gossip_entrypoint"
 if ((airdrops_enabled)); then
   default_arg --rpc-faucet-address "$faucet_address"
 fi
-echo "post entrypoint arg"
 
 default_arg --identity "$identity"
 default_arg --ledger "$ledger_dir"

--- a/k8s-cluster/src/scripts/validator-startup-script.sh
+++ b/k8s-cluster/src/scripts/validator-startup-script.sh
@@ -48,7 +48,6 @@ EOF
   exit 1
 }
 
-echo "pre positional args"
 positional_args=()
 while [[ -n $1 ]]; do
   if [[ ${1:0:1} = - ]]; then
@@ -233,12 +232,10 @@ fi
 
 echo "gossip entrypoint: $gossip_entrypoint"
 
-echo "pre default args"
 default_arg --entrypoint "$gossip_entrypoint"
 if ((airdrops_enabled)); then
   default_arg --rpc-faucet-address "$faucet_address"
 fi
-echo "post entrypoint arg"
 
 default_arg --identity "$identity"
 default_arg --vote-account "$vote_account"


### PR DESCRIPTION
previously i was dumb and was using the local cli version to build genesis and some other configs. So if we were a v.1.16.12 validator it may have a genesis from v1.17.1 or something. This is bad and sometimes incompatible. It is now fixed!

Also updated the format of names of pods and services

removed superfluous logs