### PR TITLE
fix bug for default bench-tps commands

### DIFF
--- a/k8s-cluster/src/scripts/client-startup-script.sh
+++ b/k8s-cluster/src/scripts/client-startup-script.sh
@@ -2,9 +2,17 @@
 
 clientToRun="$1"
 benchTpsExtraArgs="$2"
-clientType="${3:-thin-client}"
+clientType=
 
-shift 3
+# check if benchTpsExtraArgs is set. if not then it will get set to client-type. Which then needs to get handled appropriately
+if [[ "$benchTpsExtraArgs" == "thin-client" || "$benchTpsExtraArgs" == "tpu-client" || "$benchTpsExtraArgs" == "rpc-client" ]]; then
+    clientType=$benchTpsExtraArgs
+    benchTpsExtraArgs=
+    shift 2
+else
+    clientType="${3:-thin-client}"
+    shift 3
+fi
 
 runtime_args=()
 while [[ -n $1 ]]; do


### PR DESCRIPTION
branch name is a misnomer. just fixing bench-tps bug when we use the default commands
